### PR TITLE
Add report variable details

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,31 +158,31 @@ with information related to:
    additional variables must be configured within QGIS in order for the 
    reports to be shared effectively, outlined as follows:
   
-  - Report poster: Sends the report to a remote host using an http POST
+    - Report poster: Sends the report to a remote host using an http POST
 
-    - `dataset_qa_workbench_auth_config_id` (optional): the QGIS AuthID, 
-      as configured with the QGIS authentication manager and linked to the 
-      current user profile, represented as a string value, e.g. `'qauth01'`, 
-      and used to authenticate with the remote host (where required). 
-    - `dataset_qa_workbench_endpoint`: the REST endpoint URL, represented 
-      as a string value, e.g. `'https://service.example.com/REST'`. 
+      - `dataset_qa_workbench_auth_config_id` (optional): the QGIS AuthID, 
+        as configured with the QGIS authentication manager and linked to the 
+        current user profile, represented as a string value, e.g. `'qauth01'`, 
+        and used to authenticate with the remote host (where required). 
+      - `dataset_qa_workbench_endpoint`: the REST endpoint URL, represented 
+        as a string value, e.g. `'https://service.example.com/REST'`. 
 
-  - Report mailer: Sends the report to a recipient via email
+    - Report mailer: Sends the report to recipients via email
 
-    - `dataset_qa_workbench_sender_address`: email address of the sender, used to
-      authenticate with the mail server and given as a string value, e.g. `'noreplay@example.com'`
-    - `dataset_qa_workbench_sender_password`: sender address password for mailserver, 
-      used to authenticate with the mail server and given as a string value, e.g. `'S3cret'`
-    - `dataset_qa_workbench_recipients`: list of intended recipients, given as a single 
-      comma separated string, e.g. `'user01@example.com,user02@example.com,user03@example.com'`
-    - `dataset_qa_workbench_smtp_host`: SMTP mailserver host address, default `'smtp.gmail.com'`
-    - `dataset_qa_workbench_smtp_port`: SMTP port number as an integer, default `587`
-    - `dataset_qa_workbench_smtp_secure_connection`: a string value which describes the mail 
-      server connection security type. Valid values are `'starttls'` (default) and `'ssl'`. 
-      Use a blank string, `''`, to enforce no security policy (i.e. connect over http)
+      - `dataset_qa_workbench_sender_address`: email address of the sender, used to
+        authenticate with the mail server and given as a string value, e.g. `'noreply@example.com'`
+      - `dataset_qa_workbench_sender_password`: sender address password for mailserver, 
+        used to authenticate with the mail server and given as a string value, e.g. `'S3cret'`
+      - `dataset_qa_workbench_recipients`: list of intended recipients, given as a single 
+        comma separated string, e.g. `'user01@example.com,user02@example.com,user03@example.com'`
+      - `dataset_qa_workbench_smtp_host`: SMTP mailserver host address, default `'smtp.gmail.com'`
+      - `dataset_qa_workbench_smtp_port`: SMTP port number as an integer, default `587`
+      - `dataset_qa_workbench_smtp_secure_connection`: a string value which describes the mail 
+        server connection security type. Valid values are `'starttls'` (default) and `'ssl'`. 
+        Use a blank string, `''`, to enforce no security policy (i.e. connect over http)
 
-   Note that all of these elements may be configured globally for the current QGIS 
-   user profile under the menu item for _Settings -> Options... -> Variables_.
+     Note that all of these elements may be configured globally for the current QGIS 
+     user profile under the menu item for _Settings -> Options... -> Variables_.
 
 1. If you are validating a loaded layer, the _Add validation report to layer 
    metadata_ button will be enabled. In this case you have the option to 

--- a/README.md
+++ b/README.md
@@ -138,13 +138,13 @@ with information related to:
    QGIS in its global `user_full_name` variable. If you wish to provide a 
    different name:
    
-   1. Navigate to _Settings -> Options... -> Variables
+   1. Navigate to _Settings -> Options... -> Variables_
    
    2. Define a new variable named `dataset_qa_workbench`
    
    3. Set an appropriate value. The plugin will use it as the author of 
       validation reports
-      
+
 1. If applicable, the checklist may specify a post-validation action. In this 
    case, the _Run post validation_ and _Configure and run post validation..._ 
    buttons will be enabled.
@@ -153,7 +153,37 @@ with information related to:
    validation procedure to some third-party. Some examples include emailing the 
    validation report to a list of recipients or POSTing the report to some 
    centralized host by using a suitable REST API
-   
+
+1. When checklists are designed to automatically share output reports, 
+   additional variables must be configured within QGIS in order for the 
+   reports to be shared effectively, outlined as follows:
+  
+  - Report poster: Sends the report to a remote host using an http POST
+
+    - `dataset_qa_workbench_auth_config_id` (optional): the QGIS AuthID, 
+      as configured with the QGIS authentication manager and linked to the 
+      current user profile, represented as a string value, e.g. `'qauth01'`, 
+      and used to authenticate with the remote host (where required). 
+    - `dataset_qa_workbench_endpoint`: the REST endpoint URL, represented 
+      as a string value, e.g. `'https://service.example.com/REST'`. 
+
+  - Report mailer: Sends the report to a recipient via email
+
+    - `dataset_qa_workbench_sender_address`: email address of the sender, used to
+      authenticate with the mail server and given as a string value, e.g. `'noreplay@example.com'`
+    - `dataset_qa_workbench_sender_password`: sender address password for mailserver, 
+      used to authenticate with the mail server and given as a string value, e.g. `'S3cret'`
+    - `dataset_qa_workbench_recipients`: list of intended recipients, given as a single 
+      comma separated string, e.g. `'user01@example.com,user02@example.com,user03@example.com'`
+    - `dataset_qa_workbench_smtp_host`: SMTP mailserver host address, default `'smtp.gmail.com'`
+    - `dataset_qa_workbench_smtp_port`: SMTP port number as an integer, default `587`
+    - `dataset_qa_workbench_smtp_secure_connection`: a string value which describes the mail 
+      server connection security type. Valid values are `'starttls'` (default) and `'ssl'`. 
+      Use a blank string, `''`, to enforce no security policy (i.e. connect over http)
+
+   Note that all of these elements may be configured globally for the current QGIS 
+   user profile under the menu item for _Settings -> Options... -> Variables_.
+
 1. If you are validating a loaded layer, the _Add validation report to layer 
    metadata_ button will be enabled. In this case you have the option to 
    include the validation report in the layer's metadata. This modifies 
@@ -167,7 +197,7 @@ with information related to:
      validation reports that might be there)
      
    - A new line is also appended to the metadata's _History_ section. This
-     include's the validation report's generation timestamp and the overal
+     include's the validation report's generation timestamp and the overall
      validation result
      
 1. Finally, the report may also be saved as a PDF file by selecting an 


### PR DESCRIPTION
Add details on the configuration of environment variables that are required for the utilisation of remote report sharing tools, including the report poster and report mailer tools